### PR TITLE
Fixed issue #11 

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -312,12 +312,13 @@
 
     // if the isn't going to play automatically and the first image is
     // loaded make sure to render it
-    if( this.$element.find("img")[0] == element &&
-        (event && event.type !== "error") &&
+    if( this.$element.find("img")[0] == element && 
         (!this.options.autoplay || !this.options.autoplay.enabled) ){
-      this.goto(0);
-      this.$element.trigger("tau.init");
-      initTriggered = true;
+      if( !event || event.type !== "error") {
+        this.goto(0);
+        this.$element.trigger("tau.init");
+        initTriggered = true;
+      }
     }
 
     this.loadedCount++;


### PR DESCRIPTION
If image is already loaded by the time imageLoaded is called, then do not switch based on an event variable