### PR TITLE
Fixes Issue #13

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -496,7 +496,7 @@
       return;
     }
 
-    if( !$(event.target).closest(".tau").length ){
+    if( !this.tracking ){
       return;
     }
 


### PR DESCRIPTION
Re #13 

We should not block the release operation just because the event did not originate from inside the active element